### PR TITLE
Persist chain metadata

### DIFF
--- a/index/src/local/mutation_index/results.rs
+++ b/index/src/local/mutation_index/results.rs
@@ -31,7 +31,7 @@ impl<'i, Q: Borrow<EntityQuery>> Iterator for MutationResultsIterator<'i, Q> {
             query.paging = Some(self.next_page.clone()?);
 
             if self.max_pages == 0 {
-                error!(
+                warn!(
                     "Too many page fetched. Stopping here. Last query={:?}",
                     query
                 );


### PR DESCRIPTION
Allows faster start by preventing from having to scan the whole chain on each start. Also decreases initial memory usage by preventing the the mmap chain from being faulted to memory right from the beginning. 